### PR TITLE
Fix segmentColumn infinite loop on heading/stat-field collisions

### DIFF
--- a/scripts/import/pdf/layout.js
+++ b/scripts/import/pdf/layout.js
@@ -103,7 +103,9 @@ const isFellRunIn = (l) => {
 const isStatName = (l) => isAvara(l.font) && l.size < HEAD_MIN;
 const isItalicLine = (l) => l.spans.length > 0 && l.spans.every((s) => isItalic(s.font) || !s.text.trim());
 const isFieldLine = (l) => /^(HP\b|Armor\b|Damage\b|Instinct\b|Special qualit)/i.test(l.text.trim());
-const isHpLine = (l) => /^HP\b/i.test(l.text.trim());
+// A real HP field carries its value right after the label ("HP 26; Armor 3 (…)"); prose that merely
+// starts with "HP" (Book I's harm chapter: "HP. Good for them!…") must not anchor a stat block.
+const isHpLine = (l) => /^HP\s*:?\s*\d/i.test(l.text.trim());
 const hpAhead = (rows, i) => {
 	// Look a few rows ahead for the HP line — a name can be followed by an icon and one or two
 	// wrapped tag lines before HP (e.g. Bronze colossus, Iron hound, Draventao).
@@ -265,18 +267,25 @@ function segmentColumn(rows, base) {
 		if (c0?.boxEnd) { blocks.push({ type: "boxend" }); i++; continue; }
 
 		// STAT BLOCK — anchored on an HP line; capture name/tags through the moves.
+		// If the collector consumes nothing (its anchor row is itself a break condition — e.g. Book I's
+		// "Armor" section heading matches the field-line anchor), fall through to the branches below
+		// instead of spinning on this row forever.
 		if (looksStatStart(rows, i)) {
 			const { endIdx, lines, icon } = collectStatBlock(rows, i);
-			blocks.push({ type: "statblock", lines, icon });
-			i = endIdx;
-			continue;
+			if (endIdx > i) {
+				blocks.push({ type: "statblock", lines, icon });
+				i = endIdx;
+				continue;
+			}
 		}
 		// SETTLEMENT BLOCK — anchored on the "Size … / Population" fields; one bordered card.
 		if (looksSettlementStart(rows, i)) {
 			const { endIdx, lines } = collectSettlementBlock(rows, i, base);
-			blocks.push({ type: "settlement", lines });
-			i = endIdx;
-			continue;
+			if (endIdx > i) {
+				blocks.push({ type: "settlement", lines });
+				i = endIdx;
+				continue;
+			}
 		}
 		// TABLE — roll/result rows, optionally preceded by a dice header. The header is either one
 		// Avara cell ("1d12 theme") or a split "1d6" + small-caps name (the d6 site/sign tables).

--- a/tests/import/pdf/layout.test.js
+++ b/tests/import/pdf/layout.test.js
@@ -97,3 +97,56 @@ describe("extractArticle — Aratis (4-column prose)", () => {
 		expect(r.body).toMatch(/<h3>Various treasures<\/h3>\s*<ul><li>A blanket woven/);
 	});
 });
+
+describe("extractArticle — stat-block anchors vs. same-named headings (segmentColumn guard)", () => {
+	// Book I's harm chapter has section headings that share names with stat-block fields ("Armor",
+	// "Damage") and prose that starts with "HP". Pre-guard, looksStatStart fired on such a heading,
+	// collectStatBlock immediately broke on it (endIdx === i), and segmentColumn spun on that row
+	// until the heap died. These synthetic pages reproduce both trigger shapes; if this suite hangs,
+	// the guard regressed.
+	const L = (text, y, { font = "ACaslonPro-Regular", size = 9 } = {}) =>
+		({ bbox: [36, y, 220, y + size], text, font, size, spans: [{ font, size, text }] });
+	// Page 1: an "Armor" heading with "HP"-leading prose nearby — prose with no HP value must not
+	// count as a stat-block anchor (pre-fix, isHpLine matched it and the heading row spun).
+	const proseTrap = {
+		width: 400, height: 600,
+		lines: [
+			L("Harm & recovery", 40, { font: "Avara-Bold", size: 18 }),
+			L("Armor", 70, { font: "Avara-Bold", size: 12 }),
+			L("It reduces harm. Some attacks ignore", 85),
+			L("HP. Good for them! It still helps.", 100),
+		],
+	};
+	// Page 2: a "Damage" heading directly above a real stat block. looksStatStart fires on the
+	// heading itself (field-name match + true HP line in range); the collector consumes nothing, and
+	// the guard must fall through to the heading branch, then collect the block off its real anchor.
+	const headingTrap = {
+		width: 400, height: 600,
+		lines: [
+			L("Damage", 200, { font: "Avara-Bold", size: 12 }),
+			L("Iron hound", 215, { font: "Avara-Bold", size: 9 }),
+			L("HP 12; Armor 3 (metal hide)", 230, { font: "ACaslonPro-Bold", size: 9 }),
+			L("Instinct: to hunt", 245, { font: "ACaslonPro-Italic", size: 9 }),
+		],
+	};
+	const doc = extractArticle([proseTrap, headingTrap], { title: "Harm & recovery" });
+	const body = renderHtml(doc);
+	const pageBlocks = (s) => [...s.left, ...s.right].flatMap((c) => c.blocks);
+
+	it("terminates, keeping the field-named headings as headings", () => {
+		expect(body).toContain("<h2>Armor</h2>");
+		expect(body).toContain("<h2>Damage</h2>");
+	});
+
+	it("keeps HP-leading prose as prose (no digit after HP = no stat-block anchor)", () => {
+		expect(pageBlocks(doc.sections[0]).filter((b) => b.type === "statblock")).toHaveLength(0);
+		expect(body).toContain("HP. Good for them!");
+	});
+
+	it("still collects the real stat block from its name + valued HP line", () => {
+		const sbs = pageBlocks(doc.sections[1]).filter((b) => b.type === "statblock");
+		expect(sbs).toHaveLength(1);
+		expect(sbs[0].lines.map((l) => l.text)).toContain("Iron hound");
+		expect(sbs[0].lines.some((l) => /^HP 12/.test(l.text))).toBe(true);
+	});
+});


### PR DESCRIPTION
## The bug

Running the PDF importer's layout extraction over pages where a **section heading shares a name with a stat-block field** ("Armor", "Damage" — e.g. Book I's harm & recovery chapter) hangs the process until the heap dies.

Chain: `looksStatStart` fires on the heading row (it matches `isFieldLine`, and prose starting with "HP" nearby satisfies `hpAhead`), but `collectStatBlock` immediately breaks on that same row (it's a real heading), returning `endIdx === i`. `segmentColumn` then loops on row `i` forever. Reproduced on `main` and on `0.13.0`.

## The fix

- Both block collectors (`collectStatBlock`, `collectSettlementBlock`) now fall through to the later branches when they consume nothing, so a row that anchors-but-immediately-breaks is handled as the heading/paragraph it actually is instead of spinning.
- `isHpLine` now requires a digit after "HP" (`HP 26; Armor 3`), so prose that merely starts with "HP" ("HP. Good for them!") can't anchor a stat block.

## Test

Added a regression suite to `tests/import/pdf/layout.test.js` with two synthetic pages reproducing both trigger shapes (heading + HP-prose in range; heading directly above a real stat block). Verified the suite hangs without the fix and passes with it; full run is green (1666 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)