### PR TITLE
stonetop-art README: document that extract-art can't reproduce shipped hashes across toolchains

### DIFF
--- a/stonetop-art/README.md
+++ b/stonetop-art/README.md
@@ -12,25 +12,51 @@ contains only "trade dress" (UI chrome and the small marker glyphs under
 
 ## What goes here
 
-| Subfolder            | Source                       | How to get it                            |
-| -------------------- | ---------------------------- | ---------------------------------------- |
-| `wonders/<hash>.png` | Book II                      | `npm run extract-art -- <Book_II.pdf>`   |
-| `arcana/<slug>.png`  | Book II (separate tool)      | supply manually                          |
-| `steading/*.png`     | core book (Book I)           | supply manually                          |
-| `playbooks/*.png`    | core book (Book I)           | supply manually                          |
+| Subfolder            | Source                       | How to get it                                          |
+| -------------------- | ---------------------------- | ------------------------------------------------------ |
+| `wonders/<hash>.png` | Book II                      | `node scripts/import/pdf/build-journal.js` (see below) |
+| `arcana/<slug>.png`  | Book II (separate tool)      | supply manually                                        |
+| `steading/*.png`     | core book (Book I)           | supply manually                                        |
+| `playbooks/*.png`    | core book (Book I)           | supply manually                                        |
 
-`npm run extract-art` reliably regenerates only the **wonders** illustrations: they are
-content-addressed (`<sha256>.png`) by the same pipeline that produced the shipped references, so the
-filenames always match. The **arcana** images were cropped/processed with a separate CLI tool (raw
-PDF extraction does not reproduce them byte-for-byte), and **steading/playbook** art comes from the
-core book — supply all three manually by dropping correctly-named files into the matching subfolder.
+The **arcana** images were cropped/processed with a separate CLI tool (raw PDF extraction does not
+reproduce them byte-for-byte), and **steading/playbook** art comes from the core book — supply all
+three manually by dropping correctly-named files into the matching subfolder. Being slug-named,
+any correctly-named file resolves, whatever produced it.
+
+The **wonders** illustrations are content-addressed (`<sha256>.png`) — and that comes with a
+caveat.
+
+## The content-addressing caveat (read before extracting)
+
+A wonders filename hashes the **final encoded PNG bytes**, and the encoder's zlib deflate step
+produces different bytes on different zlib builds — pixel-identical images, different hashes.
+(Verified the hard way: an exhaustive deflate parameter sweep and a pako fallback both fail to
+match across toolchains.) Consequences:
+
+- **You cannot expect to reproduce the hashes in the committed pack source.** `npm run
+  extract-art` alone regenerates the *images*, but on a different zlib build their filenames won't
+  match the shipped refs.
+- Art files and the pack refs that point at them must come from the **same importer run on the
+  same machine**. Run the full journal build — `BOOK_PDF=/path/to/Book_II.pdf node
+  scripts/import/pdf/build-journal.js` — which extracts the art *and* rewrites the pack source
+  refs together, then recompile packs (`npm run pack`). Re-running on the same machine is stable;
+  refs only churn when the toolchain's zlib changes.
+- Recurring marker glyphs (trade dress, shipped in `assets/`) are recognized and routed *out* of
+  this folder by sha256 via `scripts/import/pdf/trade-dress.json`. On a new toolchain your marker
+  hashes won't be listed there yet — if small swirl/marker glyphs start appearing under
+  `wonders/`, add your toolchain's hashes to that routing table (keep the existing entries; it is
+  a merged, multi-toolchain list).
+
+The importers shell out to `mutool` (MuPDF) and poppler's `pdfimages`/`pdftoppm`; install those
+first (`apt install mupdf-tools poppler-utils`, `dnf install mupdf poppler-utils`, or similar).
 
 ## Using it on a Foundry server
 
 Image refs point at `stonetop-art/...`, which lives *outside* `Data/systems/stonetop/`, so it
 **survives manifest re-installs/updates** of the system.
 
-1. Populate this folder locally (run the extractor and/or drop in your manual art).
+1. Populate this folder locally (run the journal build and/or drop in your manual art).
 2. Copy it to your server's data dir as **`Data/stonetop-art/`** (one-time), then re-sync after
    meaningful re-imports — `rsync` only transfers changed files, since wonders art is
    content-addressed.


### PR DESCRIPTION
## The problem

The README says `npm run extract-art` "reliably regenerates only the **wonders** illustrations" and that "the filenames always match" the shipped refs. On a different machine, they don't: the content-addressed filename hashes the **final encoded PNG bytes**, and zlib's deflate output differs across zlib builds. Pixel-identical extractions produce different hashes on a different toolchain, so every shipped `stonetop-art/wonders/<hash>.png` ref comes up as a missing image.

This isn't hypothetical — I hit it moving machines, and dug in before concluding it's unfixable at reasonable cost: an exhaustive sweep of the encoder's deflate parameters and a pako fallback both fail to reproduce the committed hashes (same pixels, different bytes).

## The change (docs only)

- Replace the reproducibility claim with the workflow that actually works: run the full `build-journal.js`, which extracts the art **and** rewrites the pack source refs in the same run, then `npm run pack`. Same-machine re-runs stay stable.
- Document `trade-dress.json`'s role: marker glyphs are routed out of `stonetop-art/` by sha256, so a new toolchain needs its own hashes added to that (multi-toolchain, merged) table — otherwise markers start landing in `wonders/` as illustrations.
- Note the `mutool` + poppler prerequisites.

No code changes; slug-named categories (arcana/steading/playbooks) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)