### PR TITLE
Add pack:module — compile a content module's packs with the system's tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "pack": "node scripts/compendium-pack/pack.js",
     "unpack": "node scripts/compendium-pack/unpack.js",
     "extract-art": "node scripts/import/pdf/extract-art.js",
-    "build-arcana": "node scripts/import/pdf/build-arcana.js"
+    "build-arcana": "node scripts/import/pdf/build-arcana.js",
+    "pack:module": "node scripts/pack-module.js"
   },
   "devDependencies": {
     "@foundryvtt/foundryvtt-cli": "^3.0.3",

--- a/scripts/import/ids.js
+++ b/scripts/import/ids.js
@@ -21,6 +21,7 @@ const KEY_PREFIX = {
 	Actor:        "!actors",
 	Item:         "!items",
 	JournalEntry: "!journal",
+	Macro:        "!macros",
 };
 
 /** The `_key` for a top-level pack document of the given type. */

--- a/scripts/pack-module.js
+++ b/scripts/pack-module.js
@@ -1,0 +1,46 @@
+// Compile a content module's pack source (JSON) into LevelDB, using this package's
+// @foundryvtt/foundryvtt-cli — so a companion module full of compendium content doesn't need its
+// own node toolchain. Point MODULE_DIR at the module; every subdirectory of its packs/src/ is
+// compiled to packs/<name>/. Ids are deterministic (written by the importers), so no id/folder
+// bookkeeping is needed here.
+//
+//   MODULE_DIR=../my-module npm run pack:module
+import { compilePack } from "@foundryvtt/foundryvtt-cli";
+import { promises as fs } from "fs";
+
+const MODULE = process.env.MODULE_DIR;
+
+async function main() {
+	if (!MODULE) {
+		console.error("Usage: MODULE_DIR=/path/to/module npm run pack:module");
+		process.exit(1);
+	}
+	const srcRoot = `${MODULE}/packs/src`;
+	let packs;
+	try {
+		packs = (await fs.readdir(srcRoot, { withFileTypes: true })).filter((e) => e.isDirectory() && !e.name.startsWith("_")).map((e) => e.name);
+	} catch {
+		console.error(`No pack source at ${srcRoot}`);
+		process.exit(1);
+	}
+	if (!packs.length) {
+		console.error(`No pack source directories under ${srcRoot}`);
+		process.exit(1);
+	}
+	for (const pack of packs) {
+		const dest = `${MODULE}/packs/${pack}`;
+		await fs.rm(dest, { recursive: true, force: true });
+		await fs.mkdir(dest, { recursive: true });
+		try {
+			await compilePack(`${srcRoot}/${pack}`, dest, { nedb: false, log: true, recursive: true });
+		} catch (err) {
+			// Node v24 + abstract-level teardown race: iterator cleanup races with DB close.
+			// All files are written before this throws, so it's safe to ignore.
+			if (err.code !== "LEVEL_ITERATOR_NOT_OPEN") throw err;
+		}
+	}
+}
+
+// process.exit prevents a Node v24 / abstract-level teardown race where open
+// iterators are garbage-collected after the DB closes, causing a spurious crash.
+main().then(() => process.exit(0)).catch(err => { console.error(err); process.exit(1); });

--- a/tests/import/ids.test.js
+++ b/tests/import/ids.test.js
@@ -23,9 +23,10 @@ describe("documentKey", () => {
 		expect(documentKey("Actor", "abc")).toBe("!actors!abc");
 		expect(documentKey("Item", "abc")).toBe("!items!abc");
 		expect(documentKey("JournalEntry", "abc")).toBe("!journal!abc");
+		expect(documentKey("Macro", "abc")).toBe("!macros!abc");
 	});
 
 	it("throws on an unknown document type", () => {
-		expect(() => documentKey("Macro", "abc")).toThrow();
+		expect(() => documentKey("Scene", "abc")).toThrow();
 	});
 });


### PR DESCRIPTION
Adds `npm run pack:module`: point `MODULE_DIR` at a Foundry module and every subdirectory of its `packs/src/` is compiled to `packs/<name>/` LevelDB with this package's `@foundryvtt/foundryvtt-cli` — so a companion module that is pure compendium content (journals, maps, macros for a GM's own book extractions) needs no node toolchain of its own.

```bash
MODULE_DIR=../my-companion-module npm run pack:module
```

Also gives the deterministic-id helper a `Macro` key prefix (`!macros`) so Macro compendia can be generated the same way as the other document types (one-line `ids.js` change + test).

Context: I keep my (non-redistributable) Book I journal and map extractions in a private companion module built by the same importer pipeline; this is the generic piece of that workflow, and it seemed broadly useful for anyone building content modules against the system. No changes to existing scripts or the system runtime.

Note for the 0.13.0 merge: `package.json` gains one script line; `scripts/pack-module.js` is new, so the `scripts/` → `scripts/compendium-pack/` reorganization there won't conflict beyond that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)