### PR TITLE
Add hover descriptions to stats and debilities (book p. 53)

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -284,6 +284,21 @@
 					"int": "+INT",
 					"wis": "+WIS",
 					"cha": "+CHA"
+				},
+				"desc": {
+					"str": "Your physical power and your ability to use it. Roll +STR to Clash, or to Defy Danger with raw might or power.",
+					"dex": "Your grace and fine motor control. Roll +DEX to Let Fly, or to Defy Danger with speed, agility, finesse.",
+					"int": "Your memory, learning, and quick thinking. Roll +INT to Know Things, or to Defy Danger via expertise or with a clever plan.",
+					"wis": "Your intuition, self-control, and awareness. Roll +WIS to Seek Insight, or when you rely on your willpower or senses to Defy Danger.",
+					"con": "Your stamina, grit, determination, and endurance. Roll +CON to Defend, or to Defy Danger by holding steady or enduring hardship.",
+					"cha": "Your ability to charm and connect with others, and to get a read on what others want. Roll +CHA to Persuade, or to Defy Danger socially."
+				}
+			},
+			"debilities": {
+				"desc": {
+					"weakened": "Fatigued, tired, sluggish, shaky. Take disadvantage when rolling +STR or +DEX.",
+					"dazed": "Out of it, befuddled, not thinking clearly. Take disadvantage when rolling +INT or +WIS.",
+					"miserable": "Greatly distressed, angry, unwell, in pain. Take disadvantage when rolling +CON or +CHA."
 				}
 			},
 			"attributes": {

--- a/src/actors/character/CharacterDebilities.js
+++ b/src/actors/character/CharacterDebilities.js
@@ -1,10 +1,12 @@
 import {DebilitySnapshotBuilder} from "../../model/snapshot/character/CharacterSnapshot.js";
 
 const _DEBILITY_DEFS = [
-	{key: "weakened",  name: "Weakened",  stats: ["str", "dex"]},
-	{key: "dazed",     name: "Dazed",     stats: ["int", "wis"]},
-	{key: "miserable", name: "Miserable", stats: ["con", "cha"]},
+	{key: "weakened",  name: "Weakened",  stats: ["str", "dex"], descKey: "stonetop.character.debilities.desc.weakened"},
+	{key: "dazed",     name: "Dazed",     stats: ["int", "wis"], descKey: "stonetop.character.debilities.desc.dazed"},
+	{key: "miserable", name: "Miserable", stats: ["con", "cha"], descKey: "stonetop.character.debilities.desc.miserable"},
 ];
+
+const _localize = (key) => globalThis.game?.i18n?.localize?.(key) ?? key;
 
 export class CharacterDebilities {
 	constructor(actor) {
@@ -19,12 +21,13 @@ export class CharacterDebilities {
 
 	buildDebilitiesSnapshot() {
 		const opts = this._actor.system?.attributes?.debilities?.options ?? {};
-		return _DEBILITY_DEFS.map(({key, name, stats}) =>
+		return _DEBILITY_DEFS.map(({key, name, stats, descKey}) =>
 			new DebilitySnapshotBuilder()
 				.withKey(key)
 				.withName(name)
 				.withActive(!!(opts[key]?.value))
 				.withStats(stats)
+				.withDescription(_localize(descKey))
 				.build()
 		);
 	}

--- a/src/actors/character/CharacterStats.js
+++ b/src/actors/character/CharacterStats.js
@@ -2,13 +2,15 @@ import { StatSnapshot } from "../../model/snapshot/character/CharacterSnapshot.j
 import { Stats } from "../../model/data/character/Stats.js";
 
 const _STAT_DEFS = {
-	str: { name: "Strength",     abbr: "STR" },
-	dex: { name: "Dexterity",    abbr: "DEX" },
-	int: { name: "Intelligence", abbr: "INT" },
-	wis: { name: "Wisdom",       abbr: "WIS" },
-	con: { name: "Constitution", abbr: "CON" },
-	cha: { name: "Charisma",     abbr: "CHA" },
+	str: { name: "Strength",     abbr: "STR", descKey: "stonetop.character.stats.desc.str" },
+	dex: { name: "Dexterity",    abbr: "DEX", descKey: "stonetop.character.stats.desc.dex" },
+	int: { name: "Intelligence", abbr: "INT", descKey: "stonetop.character.stats.desc.int" },
+	wis: { name: "Wisdom",       abbr: "WIS", descKey: "stonetop.character.stats.desc.wis" },
+	con: { name: "Constitution", abbr: "CON", descKey: "stonetop.character.stats.desc.con" },
+	cha: { name: "Charisma",     abbr: "CHA", descKey: "stonetop.character.stats.desc.cha" },
 };
+
+const _localize = (key) => globalThis.game?.i18n?.localize?.(key) ?? key;
 
 export class CharacterStats {
 	constructor(actor) {
@@ -33,9 +35,9 @@ export class CharacterStats {
 	buildStatsSnapshot() {
 		const stats = this.getStats();
 		return Object.fromEntries(
-			Object.entries(_STAT_DEFS).map(([key, { name, abbr }]) => [
+			Object.entries(_STAT_DEFS).map(([key, { name, abbr, descKey }]) => [
 				key,
-				new StatSnapshot(stats.get(key), name, abbr),
+				new StatSnapshot(stats.get(key), name, abbr, _localize(descKey)),
 			])
 		);
 	}

--- a/src/model/snapshot/character/DebilitySnapshot.js
+++ b/src/model/snapshot/character/DebilitySnapshot.js
@@ -3,20 +3,23 @@
  * @property {string} name   - "Weakened" | "Dazed" | "Miserable"
  * @property {boolean} active
  * @property {string[]} stats - stat keys affected, e.g. ["str","dex"]
+ * @property {string} description - what the debility means and which rolls it hinders (book p. 53)
  */
 export class DebilitySnapshot {
 	constructor(b) {
-		this.key    = b._key;
-		this.name   = b._name;
-		this.active = b._active;
-		this.stats  = b._stats;
+		this.key         = b._key;
+		this.name        = b._name;
+		this.active      = b._active;
+		this.stats       = b._stats;
+		this.description = b._description ?? "";
 	}
 }
 
 export class DebilitySnapshotBuilder {
-	withKey(v)    { this._key    = v; return this; }
-	withName(v)   { this._name   = v; return this; }
-	withActive(v) { this._active = v; return this; }
-	withStats(v)  { this._stats  = v; return this; }
-	build()       { return new DebilitySnapshot(this); }
+	withKey(v)         { this._key         = v; return this; }
+	withName(v)        { this._name        = v; return this; }
+	withActive(v)      { this._active      = v; return this; }
+	withStats(v)       { this._stats       = v; return this; }
+	withDescription(v) { this._description = v; return this; }
+	build()            { return new DebilitySnapshot(this); }
 }

--- a/src/model/snapshot/character/StatSnapshot.js
+++ b/src/model/snapshot/character/StatSnapshot.js
@@ -3,11 +3,13 @@
  * @property {number} value
  * @property {string} name - e.g. "Strength"
  * @property {string} abbr - e.g. "STR"
+ * @property {string} description - what the stat covers and when to roll it (book p. 53)
  */
 export class StatSnapshot {
-	constructor(value, name, abbr) {
-		this.value = value;
-		this.name  = name;
-		this.abbr  = abbr;
+	constructor(value, name, abbr, description = "") {
+		this.value       = value;
+		this.name        = name;
+		this.abbr        = abbr;
+		this.description = description;
 	}
 }

--- a/templates/actor/character.hbs
+++ b/templates/actor/character.hbs
@@ -13,7 +13,8 @@
 				<div class="stonetop-debilities">
 					{{#each stonetop.debilities}}
 					<div class="stonetop-debility">
-						<label class="stonetop-debility-control">
+						<label class="stonetop-debility-control"
+						       data-tooltip="{{description}}" data-tooltip-direction="UP">
 							<span class="stonetop-debility-divider"></span>
 							<input type="checkbox" class="stonetop-debility-check"
 							       data-slug="{{key}}"

--- a/templates/actor/partials/actor-stats.hbs
+++ b/templates/actor/partials/actor-stats.hbs
@@ -1,7 +1,8 @@
 <div class="stonetop-stats-row">
 	{{#each stats}}
 	<div class="stonetop-stat" data-stat="{{@key}}">
-		<span class="stonetop-stat-roll rollable" data-roll="{{@key}}">{{name}}</span>
+		<span class="stonetop-stat-roll rollable" data-roll="{{@key}}"
+		      data-tooltip="{{description}}" data-tooltip-direction="UP">{{name}}</span>
 		<input class="stonetop-stat-input" type="number"
 		       name="system.stats.{{@key}}.value"
 		       value="{{value}}" min="-3" max="3"

--- a/tests/actors/character/CharacterDebilities.test.js
+++ b/tests/actors/character/CharacterDebilities.test.js
@@ -71,6 +71,24 @@ describe("CharacterDebilities.buildDebilitiesSnapshot", () => {
 		expect(snap.find(d => d.key === "dazed").stats).toEqual(["int", "wis"]);
 		expect(snap.find(d => d.key === "miserable").stats).toEqual(["con", "cha"]);
 	});
+
+	it("carries a description for every debility (localization key when no i18n)", () => {
+		const snap = new CharacterDebilities(makeDebilityActor()).buildDebilitiesSnapshot();
+		for (const key of ["weakened", "dazed", "miserable"]) {
+			expect(snap.find(d => d.key === key).description).toBe(`stonetop.character.debilities.desc.${key}`);
+		}
+	});
+
+	it("localizes the description through game.i18n when available", () => {
+		const prev = globalThis.game;
+		globalThis.game = { i18n: { localize: (k) => (k === "stonetop.character.debilities.desc.dazed" ? "Out of it, befuddled" : k) } };
+		try {
+			const snap = new CharacterDebilities(makeDebilityActor()).buildDebilitiesSnapshot();
+			expect(snap.find(d => d.key === "dazed").description).toBe("Out of it, befuddled");
+		} finally {
+			globalThis.game = prev;
+		}
+	});
 });
 
 // -- applyDebilityRollMode -----------------------------------------------------

--- a/tests/actors/character/CharacterStats.test.js
+++ b/tests/actors/character/CharacterStats.test.js
@@ -87,4 +87,22 @@ describe("CharacterStats.buildStatsSnapshot", () => {
 	it("defaults to 0 when a stat is missing from the actor", () => {
 		expect(new CharacterStats(new FakeCharacterActorBuilder().build()).buildStatsSnapshot().wis.value).toBe(0);
 	});
+
+	it("carries a description for every stat (localization key when no i18n)", () => {
+		const snap = new CharacterStats(new FakeCharacterActorBuilder().build()).buildStatsSnapshot();
+		for (const key of ["str", "dex", "int", "wis", "con", "cha"]) {
+			expect(snap[key].description).toBe(`stonetop.character.stats.desc.${key}`);
+		}
+	});
+
+	it("localizes the description through game.i18n when available", () => {
+		const prev = globalThis.game;
+		globalThis.game = { i18n: { localize: (k) => (k === "stonetop.character.stats.desc.str" ? "Your physical power" : k) } };
+		try {
+			const snap = new CharacterStats(new FakeCharacterActorBuilder().build()).buildStatsSnapshot();
+			expect(snap.str.description).toBe("Your physical power");
+		} finally {
+			globalThis.game = prev;
+		}
+	});
 });


### PR DESCRIPTION
Picks up two "nice to have" items from TODO.md: *add descriptions to debilities for hover over (p 53)* and *add descriptions to stats for hover over (p 53)*.

Hovering a stat name or a debility checkbox on the character sheet now shows the book's one-line explanation (what the stat covers and which moves roll it; what the debility means and which rolls it hinders), using Foundry's native `data-tooltip` — no new listeners or CSS.

**How it works**

- `StatSnapshot` / `DebilitySnapshot` gain a `description` field, filled from new localization strings (`stonetop.character.stats.desc.*`, `stonetop.character.debilities.desc.*`) at snapshot-build time. Outside Foundry the localizer falls back to the key, same pattern `CharacterInventory.js` already uses.
- `actor-stats.hbs` puts the tooltip on the stat-name span, `character.hbs` on the debility control label, both `data-tooltip-direction="UP"` so the tooltip stays clear of the inputs.

Text is from Book I p. 53 (CC BY-SA 4.0), lightly trimmed to tooltip length.

**Tests**: 4 new (description present for all 6 stats / 3 debilities; localization goes through `game.i18n` when available). Full suite: 1924 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)