### PR TITLE
Show the steading's Prosperity on the inventory tab (re-opened from #37)

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -255,7 +255,10 @@
 				"light": "For a <strong>light load</strong> (<em>quick & quiet</em>), mark up to 3 ◆",
 				"normal": "For a <strong>normal load</strong>, mark 4–6 ◆",
 				"heavy": "For a <strong>heavy load</strong> (<em>noisy, slow, hot, quick to tire</em>), mark 7–9 ◆"
-			}
+			},
+			"prosperity": "Prosperity",
+			"prosperityLacking": "(lacking)",
+			"prosperityLackingNote": "The steading is <em>lacking</em>: treat Prosperity as if it's 1 lower than it is."
 		},
 		"settings": {
 			"hideRollMode": {

--- a/src/actors/character/CharacterInventory.js
+++ b/src/actors/character/CharacterInventory.js
@@ -2,6 +2,7 @@ import {
 	LoadOptionSnapshot,
 	LoadSnapshotBuilder,
 	OutfitSnapshotBuilder,
+	ProsperitySnapshot,
 } from "../../model/snapshot/character/CharacterSnapshot.js";
 import {EmbeddedOutfitItemBuilder} from "../../model/data/character/EmbeddedOutfitItem.js";
 import {OutfitItemBuilder} from "../../model/data/character/OutfitItem.js";
@@ -9,11 +10,12 @@ import { ResourceController } from "./ResourceController.js";
 import { buildOutfitColumn } from "../../model/snapshot/character/outfitSections.js";
 
 export class CharacterInventory {
-	constructor(actor, inventoryRepo, outfitItems, resourceController) {
+	constructor(actor, inventoryRepo, outfitItems, resourceController, steadingRepo = null) {
 		this._actor = actor;
 		this._repo = inventoryRepo;
 		this._outfitItems = outfitItems;
 		this._resourceController = resourceController;
+		this._steadingRepo = steadingRepo;
 	}
 
 	get checked()     { return this._actor.system?.inventory?.checked     ?? {}; }
@@ -107,7 +109,13 @@ export class CharacterInventory {
 			.withSmallSections(buildOutfitColumn(repoItems, embeddedItems, checked, "small", resourceFn))
 			.withSmallPool(ResourceController.build({ max: 9, title: null, labels: [] }, this.smallPool))
 			.withOtherItems(this.otherItems)
+			.withProsperity(this.buildProsperitySnapshot())
 			.build();
+	}
+
+	buildProsperitySnapshot() {
+		const p = this._steadingRepo?.getProsperity() ?? null;
+		return p ? new ProsperitySnapshot(p.steadingName, p.value, p.lacking) : null;
 	}
 
 	buildLoadSnapshot(loadLevel) {

--- a/src/actors/character/StonetopCharacter.js
+++ b/src/actors/character/StonetopCharacter.js
@@ -33,7 +33,7 @@ export class StonetopCharacter {
 		this._moves       = new CharacterMoves(repos.moves, actor, new ResourceController(actor, "moveResources"), factory);
 		this._playbook    = new CharacterPlaybook(actor, this._background, factory, this._origin);
 		this._possessions = new CharacterPossessions(actor, this._moves, outfitItems, repos.possessions, factory);
-		this._inventory   = new CharacterInventory(actor, repos.inventory, outfitItems, this._resourceController);
+		this._inventory   = new CharacterInventory(actor, repos.inventory, outfitItems, this._resourceController, repos.steading);
 		this._vitals      = new CharacterVitals(actor);
 		this._debilities  = new CharacterDebilities(actor);
 		this._arcana      = new CharacterArcana(actor, repos.arcana, this._stats, outfitItems, this._followers, factory, this._moves);

--- a/src/actors/character/repositories/FoundryRepositoryFactory.js
+++ b/src/actors/character/repositories/FoundryRepositoryFactory.js
@@ -5,6 +5,7 @@ import {FoundryFollowerRepository} from "./FoundryFollowerRepository.js";
 import {FoundryPossessionRepository} from "./FoundryPossessionRepository.js";
 import {FoundryPlaybookRepository} from "./FoundryPlaybookRepository.js";
 import {FoundryInsertRepository} from "./FoundryInsertRepository.js";
+import {FoundrySteadingRepository} from "./FoundrySteadingRepository.js";
 
 export class FoundryRepositoryFactory {
 	get moves() {
@@ -33,5 +34,9 @@ export class FoundryRepositoryFactory {
 
 	get inserts() {
 		return this._inserts ??= new FoundryInsertRepository();
+	}
+
+	get steading() {
+		return this._steading ??= new FoundrySteadingRepository();
 	}
 }

--- a/src/actors/character/repositories/FoundrySteadingRepository.js
+++ b/src/actors/character/repositories/FoundrySteadingRepository.js
@@ -1,10 +1,22 @@
 import {SteadingDefaults} from "../../../model/data/steading/SteadingDefaults.js";
 
 /**
- * Read-only view of the world's steading actor (the first one found — a
- * Stonetop world has exactly one) for display on character sheets.
+ * Read-only view of the world's steading actor for display on character sheets.
  */
 export class FoundrySteadingRepository {
+	/**
+	 * A world should have one steading, but strays happen (test actors left at the
+	 * default name). Prefer the one named "Stonetop", then any renamed one, then first.
+	 */
+	_findSteading() {
+		const steadings = globalThis.game?.actors?.filter?.(a => a.type === "steading") ?? [];
+		if (steadings.length <= 1) return steadings[0] ?? null;
+		const defaultName = _loc("stonetop.actor.defaultName.steading");
+		return steadings.find(a => a.name?.trim().toLowerCase() === "stonetop")
+			?? steadings.find(a => a.name !== defaultName)
+			?? steadings[0];
+	}
+
 	/**
 	 * @returns {{steadingName: string, value: number, lacking: boolean}|null}
 	 *   value is the Prosperity roll bonus; lacking mirrors the steading's
@@ -12,14 +24,18 @@ export class FoundrySteadingRepository {
 	 *   has no steading actor.
 	 */
 	getProsperity() {
-		const steading = globalThis.game?.actors?.find?.(a => a.type === "steading");
+		const steading = this._findSteading();
 		if (!steading) return null;
 		const bonuses = SteadingDefaults.attributes.prosperity.bonuses;
 		const current = steading.system?.attributes?.prosperity?.current;
 		return {
 			steadingName: steading.name,
 			value:        bonuses[current] ?? 0,
-			lacking:      !!steading.system?.debilities?.lacking,
+			lacking:      steading.system?.debilities?.lacking === true,
 		};
 	}
+}
+
+function _loc(key) {
+	return globalThis.game?.i18n?.localize?.(key) ?? key;
 }

--- a/src/actors/character/repositories/FoundrySteadingRepository.js
+++ b/src/actors/character/repositories/FoundrySteadingRepository.js
@@ -1,5 +1,3 @@
-import {SteadingDefaults} from "../../../model/data/steading/SteadingDefaults.js";
-
 /**
  * Read-only view of the world's steading actor for display on character sheets.
  */
@@ -7,14 +5,16 @@ export class FoundrySteadingRepository {
 	/**
 	 * A world should have one steading, but strays happen (test actors left at the
 	 * default name). Prefer the one named "Stonetop", then any renamed one, then first.
+	 * @returns {import("../../steading/StonetopSteading.js").StonetopSteading|null} the typed actor
 	 */
 	_findSteading() {
 		const steadings = globalThis.game?.actors?.filter?.(a => a.type === "steading") ?? [];
-		if (steadings.length <= 1) return steadings[0] ?? null;
-		const defaultName = _loc("stonetop.actor.defaultName.steading");
-		return steadings.find(a => a.name?.trim().toLowerCase() === "stonetop")
-			?? steadings.find(a => a.name !== defaultName)
-			?? steadings[0];
+		const doc = steadings.length <= 1
+			? steadings[0] ?? null
+			: steadings.find(a => a.name?.trim().toLowerCase() === "stonetop")
+				?? steadings.find(a => a.name !== _loc("stonetop.actor.defaultName.steading"))
+				?? steadings[0];
+		return doc?.typedActor ?? null;
 	}
 
 	/**
@@ -24,15 +24,7 @@ export class FoundrySteadingRepository {
 	 *   has no steading actor.
 	 */
 	getProsperity() {
-		const steading = this._findSteading();
-		if (!steading) return null;
-		const bonuses = SteadingDefaults.attributes.prosperity.bonuses;
-		const current = steading.system?.attributes?.prosperity?.current;
-		return {
-			steadingName: steading.name,
-			value:        bonuses[current] ?? 0,
-			lacking:      steading.system?.debilities?.lacking === true,
-		};
+		return this._findSteading()?.getProsperity() ?? null;
 	}
 }
 

--- a/src/actors/character/repositories/FoundrySteadingRepository.js
+++ b/src/actors/character/repositories/FoundrySteadingRepository.js
@@ -1,0 +1,25 @@
+import {SteadingDefaults} from "../../../model/data/steading/SteadingDefaults.js";
+
+/**
+ * Read-only view of the world's steading actor (the first one found — a
+ * Stonetop world has exactly one) for display on character sheets.
+ */
+export class FoundrySteadingRepository {
+	/**
+	 * @returns {{steadingName: string, value: number, lacking: boolean}|null}
+	 *   value is the Prosperity roll bonus; lacking mirrors the steading's
+	 *   "lacking" debility (treat Prosperity as 1 lower). Null when the world
+	 *   has no steading actor.
+	 */
+	getProsperity() {
+		const steading = globalThis.game?.actors?.find?.(a => a.type === "steading");
+		if (!steading) return null;
+		const bonuses = SteadingDefaults.attributes.prosperity.bonuses;
+		const current = steading.system?.attributes?.prosperity?.current;
+		return {
+			steadingName: steading.name,
+			value:        bonuses[current] ?? 0,
+			lacking:      !!steading.system?.debilities?.lacking,
+		};
+	}
+}

--- a/src/actors/steading/StonetopSteading.js
+++ b/src/actors/steading/StonetopSteading.js
@@ -58,6 +58,16 @@ export class StonetopSteading {
 		return rollMode;
 	}
 
+	/** Prosperity as character sheets display it: the steading's name, the roll bonus,
+	 *  and whether the "lacking" debility applies (treat Prosperity as 1 lower). */
+	getProsperity() {
+		return {
+			steadingName: this._actor.name,
+			value:        this.resolveBonus("prosperity") ?? 0,
+			lacking:      this._actor.system.debilities?.lacking === true,
+		};
+	}
+
 	get fortunesCurrent() {
 		return this._actor.system.attributes?.fortunes ?? 0;
 	}

--- a/src/hooks/SteadingChanged.js
+++ b/src/hooks/SteadingChanged.js
@@ -20,6 +20,18 @@ export function onSteadingCreatedOrDeleted(actor) {
 
 function rerenderCharacterSheets() {
 	for (const actor of globalThis.game?.actors ?? []) {
-		if (actor.type === "character" && actor.sheet?.rendered) actor.sheet.render();
+		if (actor.type !== "character" || !actor.sheet?.rendered) continue;
+		if (isBeingEdited(actor.sheet)) continue;
+		actor.sheet.render();
 	}
+}
+
+/** A render rebuilds the sheet's form and discards any input the player hasn't submitted
+ *  yet — so leave a sheet alone while it holds the keyboard focus. Prosperity going
+ *  momentarily stale on the sheet its player is editing is harmless; any later render
+ *  catches it up. */
+function isBeingEdited(sheet) {
+	const active = globalThis.document?.activeElement;
+	const root = sheet.element?.[0] ?? sheet.element; // jQuery (AppV1) or HTMLElement (AppV2)
+	return !!(active && root?.contains?.(active));
 }

--- a/src/hooks/SteadingChanged.js
+++ b/src/hooks/SteadingChanged.js
@@ -1,0 +1,25 @@
+/**
+ * Character sheets display steading data (Prosperity on the inventory tab). Foundry only
+ * re-renders a sheet when its own actor changes, so edits on the steading sheet would
+ * otherwise sit stale on open character sheets until something else re-rendered them.
+ * Re-render open character sheets whenever a steading's displayed fields change, or a
+ * steading appears/disappears.
+ */
+
+export function onUpdateActor(actor, changes) {
+	if (actor.type !== "steading") return;
+	const sys = changes?.system ?? {};
+	if (sys.attributes?.prosperity === undefined && sys.debilities === undefined && changes?.name === undefined) return;
+	rerenderCharacterSheets();
+}
+
+export function onSteadingCreatedOrDeleted(actor) {
+	if (actor.type !== "steading") return;
+	rerenderCharacterSheets();
+}
+
+function rerenderCharacterSheets() {
+	for (const actor of globalThis.game?.actors ?? []) {
+		if (actor.type === "character" && actor.sheet?.rendered) actor.sheet.render();
+	}
+}

--- a/src/model/snapshot/character/CharacterSnapshot.js
+++ b/src/model/snapshot/character/CharacterSnapshot.js
@@ -21,6 +21,7 @@ export {
 	OutfitItemSnapshot, OutfitItemSnapshotBuilder,
 	OutfitSection,
 	OutfitSnapshot, OutfitSnapshotBuilder,
+	ProsperitySnapshot,
 	PossessionsSnapshot,
 	PossessionItemSnapshot, PossessionItemSnapshotBuilder,
 } from "./InventorySnapshot.js";

--- a/src/model/snapshot/character/InventorySnapshot.js
+++ b/src/model/snapshot/character/InventorySnapshot.js
@@ -92,11 +92,30 @@ export class OutfitSection {
 // ── Outfit ────────────────────────────────────────────────────────────────────
 
 /**
+ * The steading's Prosperity, shown on the inventory tab because Outfit
+ * availability and the small-items pool ("mark □ equal to 4+Prosperity")
+ * depend on it.
+ * @property {string} steadingName - e.g. "Stonetop"
+ * @property {number} value - the Prosperity roll bonus, e.g. 0
+ * @property {string} label - the bonus as printed, e.g. "+0"
+ * @property {boolean} lacking - the steading has the lacking debility (treat Prosperity as 1 lower)
+ */
+export class ProsperitySnapshot {
+	constructor(steadingName, value, lacking) {
+		this.steadingName = steadingName;
+		this.value        = value;
+		this.label        = value >= 0 ? `+${value}` : `${value}`;
+		this.lacking      = lacking;
+	}
+}
+
+/**
  * @property {LoadSnapshot} load
  * @property {OutfitSection[]} regularSections
  * @property {Resource} regularPool
  * @property {OutfitSection[]} smallSections
  * @property {Resource} smallPool
+ * @property {ProsperitySnapshot|null} prosperity - null when the world has no steading
  */
 export class OutfitSnapshot {
 	constructor(b) {
@@ -106,6 +125,7 @@ export class OutfitSnapshot {
 		this.smallSections    = b._smallSections;
 		this.smallPool        = b._smallPool;
 		this.otherItems       = b._otherItems ?? "";
+		this.prosperity       = b._prosperity ?? null;
 	}
 }
 
@@ -116,6 +136,7 @@ export class OutfitSnapshotBuilder {
 	withSmallSections(v)   { this._smallSections   = v; return this; }
 	withSmallPool(v)       { this._smallPool       = v; return this; }
 	withOtherItems(v)      { this._otherItems      = v; return this; }
+	withProsperity(v)      { this._prosperity      = v; return this; }
 	build()                { return new OutfitSnapshot(this); }
 }
 

--- a/stonetop.js
+++ b/stonetop.js
@@ -20,6 +20,7 @@ import { onPreCreateActor } from "./src/hooks/PreCreateActor.js";
 import { onCreateActor } from "./src/hooks/CreateActor.js";
 import { installBrokenImageHider } from "./src/hooks/HideBrokenImages.js";
 import { onRenderChatMessage } from "./src/chat/xpMarkControl.js";
+import { onUpdateActor, onSteadingCreatedOrDeleted } from "./src/hooks/SteadingChanged.js";
 import { info } from "./src/utils/logger.js";
 import { rich, hasText } from "./src/model/snapshot/RichText.js";
 import { registerDrawTableEnricher } from "./src/journal/drawTableEnricher.js";
@@ -265,3 +266,8 @@ Hooks.on("createActor", onCreateActor);
 // -- RENDER CHAT MESSAGE ---------------------------------------
 // Binds the "Mark XP" control on 6- roll cards.
 Hooks.on("renderChatMessageHTML", onRenderChatMessage);
+// -- STEADING CHANGES ------------------------------------------
+// Character sheets show steading data (Prosperity); keep them live.
+Hooks.on("updateActor", onUpdateActor);
+Hooks.on("createActor", onSteadingCreatedOrDeleted);
+Hooks.on("deleteActor", onSteadingCreatedOrDeleted);

--- a/styles/stonetop.css
+++ b/styles/stonetop.css
@@ -1971,6 +1971,14 @@ body,
 	margin: 0 0 4px;
 }
 
+.stonetop-outfit-prosperity {
+	margin: 0 0 4px;
+}
+
+.stonetop-outfit-prosperity em {
+	opacity: 0.75;
+}
+
 .stonetop-outfit-loads {
 	list-style: none;
 	padding: 0;

--- a/templates/actor/partials/tab-equipment.hbs
+++ b/templates/actor/partials/tab-equipment.hbs
@@ -5,6 +5,12 @@
 	{{!-- Outfit header --}}
 	<div class="stonetop-outfit-header">
 		<p class="stonetop-outfit-heading">{{{localize "stonetop.inventory.outfit.heading"}}}</p>
+		{{#with stonetop.outfit.prosperity}}
+		<p class="stonetop-outfit-prosperity"
+		   {{#if lacking}}data-tooltip="{{localize "stonetop.inventory.prosperityLackingNote"}}" data-tooltip-direction="UP"{{/if}}>
+			{{steadingName}} {{localize "stonetop.inventory.prosperity"}}: <strong>{{label}}</strong>{{#if lacking}} <em>{{localize "stonetop.inventory.prosperityLacking"}}</em>{{/if}}
+		</p>
+		{{/with}}
 		<ul class="stonetop-outfit-loads">
 			<li>
 				<label class="stonetop-outfit-load-label{{#if stonetop.outfit.load.loadLevelLight}} is-checked{{/if}}">

--- a/tests/actors/character/CharacterInventory.test.js
+++ b/tests/actors/character/CharacterInventory.test.js
@@ -71,13 +71,18 @@ function makeResourceController() {
 	return new ResourceController(new FakeCharacterActorBuilder().build());
 }
 
-function makeCi(inventoryState = {}, repo = null, outfitItems = null, resourceCtrl = null) {
+function makeCi(inventoryState = {}, repo = null, outfitItems = null, resourceCtrl = null, steadingRepo = null) {
 	return new CharacterInventory(
 		makeActor(inventoryState),
 		repo ?? makeRepo(),
 		outfitItems ?? makeActorOutfitItems(),
 		resourceCtrl ?? makeResourceController(),
+		steadingRepo,
 	);
+}
+
+function makeSteadingRepo(prosperity) {
+	return { getProsperity: () => prosperity };
 }
 
 // Flatten all items across sections for a column
@@ -347,6 +352,37 @@ describe("CharacterInventory.buildSnapshot", () => {
 	it("otherItems reflects the stored value", async () => {
 		const ci = makeCi({ otherItems: "A magic ring" });
 		expect((await ci.buildSnapshot(1)).otherItems).toBe("A magic ring");
+	});
+
+	it("prosperity is null without a steading repository", async () => {
+		expect((await makeCi().buildSnapshot(1)).prosperity).toBeNull();
+	});
+
+	it("prosperity is null when the repository finds no steading", async () => {
+		const ci = makeCi({}, null, null, null, makeSteadingRepo(null));
+		expect((await ci.buildSnapshot(1)).prosperity).toBeNull();
+	});
+
+	it("prosperity carries the steading name, value, and a printed label", async () => {
+		const ci = makeCi({}, null, null, null,
+			makeSteadingRepo({ steadingName: "Stonetop", value: 0, lacking: false }));
+		const p = (await ci.buildSnapshot(1)).prosperity;
+		expect(p.steadingName).toBe("Stonetop");
+		expect(p.value).toBe(0);
+		expect(p.label).toBe("+0");
+		expect(p.lacking).toBe(false);
+	});
+
+	it("negative prosperity is printed with its own sign", async () => {
+		const ci = makeCi({}, null, null, null,
+			makeSteadingRepo({ steadingName: "Stonetop", value: -1, lacking: false }));
+		expect((await ci.buildSnapshot(1)).prosperity.label).toBe("-1");
+	});
+
+	it("prosperity carries the lacking debility", async () => {
+		const ci = makeCi({}, null, null, null,
+			makeSteadingRepo({ steadingName: "Stonetop", value: 1, lacking: true }));
+		expect((await ci.buildSnapshot(1)).prosperity.lacking).toBe(true);
 	});
 });
 

--- a/tests/actors/character/repositories/FoundrySteadingRepository.test.js
+++ b/tests/actors/character/repositories/FoundrySteadingRepository.test.js
@@ -54,4 +54,57 @@ describe("FoundrySteadingRepository.getProsperity", () => {
 		new FakeGameBuilder().withWorldActor(makeSteading({ lacking: true })).build();
 		expect(new FoundrySteadingRepository().getProsperity().lacking).toBe(true);
 	});
+
+	it("does not treat a non-boolean lacking value as active (legacy data shapes)", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ lacking: { value: true } })).build();
+		expect(new FoundrySteadingRepository().getProsperity().lacking).toBe(false);
+	});
+});
+
+// -- steading selection with strays ---------------------------------------------
+
+describe("FoundrySteadingRepository steading selection", () => {
+	it("prefers the steading named Stonetop over an earlier stray", () => {
+		new FakeGameBuilder()
+			.withWorldActor(makeSteading({ name: "New Steading", current: 1, lacking: true }))
+			.withWorldActor(makeSteading({ name: "Stonetop", current: 2 }))
+			.build();
+		const p = new FoundrySteadingRepository().getProsperity();
+		expect(p.steadingName).toBe("Stonetop");
+		expect(p.value).toBe(1);
+		expect(p.lacking).toBe(false);
+	});
+
+	it("name match is case-insensitive and trims whitespace", () => {
+		new FakeGameBuilder()
+			.withWorldActor(makeSteading({ name: "New Steading" }))
+			.withWorldActor(makeSteading({ name: " stonetop ", current: 3 }))
+			.build();
+		expect(new FoundrySteadingRepository().getProsperity().value).toBe(2);
+	});
+
+	it("prefers a renamed steading over one still at the default name", () => {
+		new FakeGameBuilder()
+			.withTranslation("stonetop.actor.defaultName.steading", "New Steading")
+			.withWorldActor(makeSteading({ name: "New Steading" }))
+			.withWorldActor(makeSteading({ name: "Marshedge", current: 0 }))
+			.build();
+		const p = new FoundrySteadingRepository().getProsperity();
+		expect(p.steadingName).toBe("Marshedge");
+		expect(p.value).toBe(-1);
+	});
+
+	it("falls back to the first steading when all are default-named", () => {
+		new FakeGameBuilder()
+			.withTranslation("stonetop.actor.defaultName.steading", "New Steading")
+			.withWorldActor(makeSteading({ name: "New Steading", current: 4 }))
+			.withWorldActor(makeSteading({ name: "New Steading", current: 0 }))
+			.build();
+		expect(new FoundrySteadingRepository().getProsperity().value).toBe(3);
+	});
+
+	it("a single steading is used whatever its name", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ name: "New Steading", current: 2 })).build();
+		expect(new FoundrySteadingRepository().getProsperity().steadingName).toBe("New Steading");
+	});
 });

--- a/tests/actors/character/repositories/FoundrySteadingRepository.test.js
+++ b/tests/actors/character/repositories/FoundrySteadingRepository.test.js
@@ -1,18 +1,21 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { FoundrySteadingRepository } from "../../../../src/actors/character/repositories/FoundrySteadingRepository.js";
+import { StonetopSteading } from "../../../../src/actors/steading/StonetopSteading.js";
 import { FakeGameBuilder } from "../../../fakes/FakeGameBuilder.js";
 
 afterEach(() => vi.unstubAllGlobals());
 
-function makeSteading({ name = "Stonetop", current = 1, lacking = false } = {}) {
-	return {
+// Ratings are stored as their actual roll bonus (see steadingRatingsSchema); the typed
+// actor wrapped here is the same StonetopSteading the steading sheet rolls with, so the
+// display can't drift from the schema without the rolls drifting too.
+function makeSteading({ name = "Stonetop", prosperity = 0, lacking = false, system } = {}) {
+	const doc = {
 		type: "steading",
 		name,
-		system: {
-			attributes: { prosperity: { current } },
-			debilities: { lacking },
-		},
+		system: system ?? { attributes: { prosperity }, debilities: { lacking } },
 	};
+	doc.typedActor = new StonetopSteading(doc);
+	return doc;
 }
 
 describe("FoundrySteadingRepository.getProsperity", () => {
@@ -30,21 +33,20 @@ describe("FoundrySteadingRepository.getProsperity", () => {
 		expect(new FoundrySteadingRepository().getProsperity()).toBeNull();
 	});
 
-	it("maps the prosperity track index to its roll bonus", () => {
-		// index 2 on the [-1, 0, +1, +2, +3] track is the +1 box
-		new FakeGameBuilder().withWorldActor(makeSteading({ current: 2 })).build();
+	it("reports the stored rating as the roll bonus", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ prosperity: 1 })).build();
 		expect(new FoundrySteadingRepository().getProsperity()).toEqual({
 			steadingName: "Stonetop", value: 1, lacking: false,
 		});
 	});
 
-	it("index 0 is the -1 box", () => {
-		new FakeGameBuilder().withWorldActor(makeSteading({ current: 0 })).build();
+	it("carries a negative rating through", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ prosperity: -1 })).build();
 		expect(new FoundrySteadingRepository().getProsperity().value).toBe(-1);
 	});
 
-	it("defaults the value to 0 when the track index is missing", () => {
-		new FakeGameBuilder().withWorldActor({ type: "steading", name: "Marshedge", system: {} }).build();
+	it("defaults the value to 0 when the steading has no attributes yet", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ name: "Marshedge", system: {} })).build();
 		expect(new FoundrySteadingRepository().getProsperity()).toEqual({
 			steadingName: "Marshedge", value: 0, lacking: false,
 		});
@@ -66,8 +68,8 @@ describe("FoundrySteadingRepository.getProsperity", () => {
 describe("FoundrySteadingRepository steading selection", () => {
 	it("prefers the steading named Stonetop over an earlier stray", () => {
 		new FakeGameBuilder()
-			.withWorldActor(makeSteading({ name: "New Steading", current: 1, lacking: true }))
-			.withWorldActor(makeSteading({ name: "Stonetop", current: 2 }))
+			.withWorldActor(makeSteading({ name: "New Steading", prosperity: -1, lacking: true }))
+			.withWorldActor(makeSteading({ name: "Stonetop", prosperity: 1 }))
 			.build();
 		const p = new FoundrySteadingRepository().getProsperity();
 		expect(p.steadingName).toBe("Stonetop");
@@ -78,7 +80,7 @@ describe("FoundrySteadingRepository steading selection", () => {
 	it("name match is case-insensitive and trims whitespace", () => {
 		new FakeGameBuilder()
 			.withWorldActor(makeSteading({ name: "New Steading" }))
-			.withWorldActor(makeSteading({ name: " stonetop ", current: 3 }))
+			.withWorldActor(makeSteading({ name: " stonetop ", prosperity: 2 }))
 			.build();
 		expect(new FoundrySteadingRepository().getProsperity().value).toBe(2);
 	});
@@ -87,7 +89,7 @@ describe("FoundrySteadingRepository steading selection", () => {
 		new FakeGameBuilder()
 			.withTranslation("stonetop.actor.defaultName.steading", "New Steading")
 			.withWorldActor(makeSteading({ name: "New Steading" }))
-			.withWorldActor(makeSteading({ name: "Marshedge", current: 0 }))
+			.withWorldActor(makeSteading({ name: "Marshedge", prosperity: -1 }))
 			.build();
 		const p = new FoundrySteadingRepository().getProsperity();
 		expect(p.steadingName).toBe("Marshedge");
@@ -97,14 +99,14 @@ describe("FoundrySteadingRepository steading selection", () => {
 	it("falls back to the first steading when all are default-named", () => {
 		new FakeGameBuilder()
 			.withTranslation("stonetop.actor.defaultName.steading", "New Steading")
-			.withWorldActor(makeSteading({ name: "New Steading", current: 4 }))
-			.withWorldActor(makeSteading({ name: "New Steading", current: 0 }))
+			.withWorldActor(makeSteading({ name: "New Steading", prosperity: 3 }))
+			.withWorldActor(makeSteading({ name: "New Steading", prosperity: 0 }))
 			.build();
 		expect(new FoundrySteadingRepository().getProsperity().value).toBe(3);
 	});
 
 	it("a single steading is used whatever its name", () => {
-		new FakeGameBuilder().withWorldActor(makeSteading({ name: "New Steading", current: 2 })).build();
+		new FakeGameBuilder().withWorldActor(makeSteading({ name: "New Steading", prosperity: 2 })).build();
 		expect(new FoundrySteadingRepository().getProsperity().steadingName).toBe("New Steading");
 	});
 });

--- a/tests/actors/character/repositories/FoundrySteadingRepository.test.js
+++ b/tests/actors/character/repositories/FoundrySteadingRepository.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { FoundrySteadingRepository } from "../../../../src/actors/character/repositories/FoundrySteadingRepository.js";
+import { FakeGameBuilder } from "../../../fakes/FakeGameBuilder.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function makeSteading({ name = "Stonetop", current = 1, lacking = false } = {}) {
+	return {
+		type: "steading",
+		name,
+		system: {
+			attributes: { prosperity: { current } },
+			debilities: { lacking },
+		},
+	};
+}
+
+describe("FoundrySteadingRepository.getProsperity", () => {
+	it("returns null when there is no game", () => {
+		expect(new FoundrySteadingRepository().getProsperity()).toBeNull();
+	});
+
+	it("returns null when the world has no steading actor", () => {
+		new FakeGameBuilder().build();
+		expect(new FoundrySteadingRepository().getProsperity()).toBeNull();
+	});
+
+	it("ignores non-steading actors", () => {
+		new FakeGameBuilder().withWorldActor({ type: "character", name: "Rhianne" }).build();
+		expect(new FoundrySteadingRepository().getProsperity()).toBeNull();
+	});
+
+	it("maps the prosperity track index to its roll bonus", () => {
+		// index 2 on the [-1, 0, +1, +2, +3] track is the +1 box
+		new FakeGameBuilder().withWorldActor(makeSteading({ current: 2 })).build();
+		expect(new FoundrySteadingRepository().getProsperity()).toEqual({
+			steadingName: "Stonetop", value: 1, lacking: false,
+		});
+	});
+
+	it("index 0 is the -1 box", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ current: 0 })).build();
+		expect(new FoundrySteadingRepository().getProsperity().value).toBe(-1);
+	});
+
+	it("defaults the value to 0 when the track index is missing", () => {
+		new FakeGameBuilder().withWorldActor({ type: "steading", name: "Marshedge", system: {} }).build();
+		expect(new FoundrySteadingRepository().getProsperity()).toEqual({
+			steadingName: "Marshedge", value: 0, lacking: false,
+		});
+	});
+
+	it("carries the lacking debility", () => {
+		new FakeGameBuilder().withWorldActor(makeSteading({ lacking: true })).build();
+		expect(new FoundrySteadingRepository().getProsperity().lacking).toBe(true);
+	});
+});

--- a/tests/actors/steading/StonetopSteading.test.js
+++ b/tests/actors/steading/StonetopSteading.test.js
@@ -175,3 +175,17 @@ describe("StonetopSteading.applyRollMode", () => {
 		expect(make().applyRollMode("defenses", "dis")).toBe("dis");
 	});
 });
+
+describe("StonetopSteading.getProsperity", () => {
+	it("reports name, the stored rating as the bonus, and the lacking debility", () => {
+		const actor = new FakeSteadingBuilder().build();
+		actor.system.attributes.prosperity = 2;
+		actor.system.debilities.lacking = true;
+		const s = new StonetopSteading(actor, fakeImprovementsRepo, fakeMoves);
+		expect(s.getProsperity()).toEqual({ steadingName: "Stonetop", value: 2, lacking: true });
+	});
+
+	it("defaults to +0 / not lacking on a fresh steading", () => {
+		expect(make().getProsperity()).toEqual({ steadingName: "Stonetop", value: 0, lacking: false });
+	});
+});

--- a/tests/fakes/FakeGameBuilder.js
+++ b/tests/fakes/FakeGameBuilder.js
@@ -4,6 +4,7 @@ import {fakeI18n} from "./foundry/FakeI18n.js";
 export class FakeGameBuilder {
 	_packs = {};
 	_worldItems = [];
+	_worldActors = [];
 
 	build() {
 		const worldItems = this._worldItems;
@@ -15,6 +16,7 @@ export class FakeGameBuilder {
 				contents: worldItems,
 				get: (id) => worldItems.find(i => i._id === id) ?? null,
 			},
+			actors: this._worldActors,
 			i18n: fakeI18n(),
 		});
 	}
@@ -26,6 +28,11 @@ export class FakeGameBuilder {
 
 	withWorldItem(item) {
 		this._worldItems.push(item);
+		return this;
+	}
+
+	withWorldActor(actor) {
+		this._worldActors.push(actor);
 		return this;
 	}
 }

--- a/tests/fakes/FakeGameBuilder.js
+++ b/tests/fakes/FakeGameBuilder.js
@@ -5,6 +5,7 @@ export class FakeGameBuilder {
 	_packs = {};
 	_worldItems = [];
 	_worldActors = [];
+	_translations = {};
 
 	build() {
 		const worldItems = this._worldItems;
@@ -17,7 +18,9 @@ export class FakeGameBuilder {
 				get: (id) => worldItems.find(i => i._id === id) ?? null,
 			},
 			actors: this._worldActors,
-			i18n: fakeI18n(),
+			// fakeI18n's format/has read the real en.json; localize still honors withTranslation()
+			// overrides and falls back to the key like fakeI18n does.
+			i18n: { ...fakeI18n(), localize: (key) => this._translations[key] ?? key },
 		});
 	}
 
@@ -33,6 +36,11 @@ export class FakeGameBuilder {
 
 	withWorldActor(actor) {
 		this._worldActors.push(actor);
+		return this;
+	}
+
+	withTranslation(key, value) {
+		this._translations[key] = value;
 		return this;
 	}
 }

--- a/tests/hooks/SteadingChanged.test.js
+++ b/tests/hooks/SteadingChanged.test.js
@@ -17,7 +17,13 @@ function setup() {
 describe("SteadingChanged.onUpdateActor", () => {
 	it("re-renders open character sheets when a steading's prosperity changes", () => {
 		const character = setup();
-		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: { current: 2 } } } });
+		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: 2 } } });
+		expect(character.sheet.render).toHaveBeenCalled();
+	});
+
+	it("re-renders when prosperity changes to 0 (a real rating)", () => {
+		const character = setup();
+		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: 0 } } });
 		expect(character.sheet.render).toHaveBeenCalled();
 	});
 
@@ -41,7 +47,7 @@ describe("SteadingChanged.onUpdateActor", () => {
 
 	it("ignores updates to non-steading actors", () => {
 		const character = setup();
-		onUpdateActor({ type: "character" }, { system: { attributes: { prosperity: { current: 2 } } } });
+		onUpdateActor({ type: "character" }, { system: { attributes: { prosperity: 2 } } });
 		expect(character.sheet.render).not.toHaveBeenCalled();
 	});
 
@@ -50,6 +56,29 @@ describe("SteadingChanged.onUpdateActor", () => {
 		new FakeGameBuilder().withWorldActor(character).build();
 		onUpdateActor({ type: "steading" }, { system: { debilities: { lacking: true } } });
 		expect(character.sheet.render).not.toHaveBeenCalled();
+	});
+
+	it("leaves a sheet alone while its player is editing it (focus inside the sheet)", () => {
+		const focused = {};
+		const editing = makeCharacter();
+		editing.sheet.element = { contains: (n) => n === focused };
+		const idle = makeCharacter();
+		idle.sheet.element = { contains: () => false };
+		new FakeGameBuilder().withWorldActor(editing).withWorldActor(idle).build();
+		vi.stubGlobal("document", { activeElement: focused });
+		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: 2 } } });
+		expect(editing.sheet.render).not.toHaveBeenCalled();
+		expect(idle.sheet.render).toHaveBeenCalled();
+	});
+
+	it("unwraps a jQuery-style element when checking focus", () => {
+		const focused = {};
+		const editing = makeCharacter();
+		editing.sheet.element = { 0: { contains: (n) => n === focused }, length: 1 };
+		new FakeGameBuilder().withWorldActor(editing).build();
+		vi.stubGlobal("document", { activeElement: focused });
+		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: 2 } } });
+		expect(editing.sheet.render).not.toHaveBeenCalled();
 	});
 });
 

--- a/tests/hooks/SteadingChanged.test.js
+++ b/tests/hooks/SteadingChanged.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { onUpdateActor, onSteadingCreatedOrDeleted } from "../../src/hooks/SteadingChanged.js";
+import { FakeGameBuilder } from "../fakes/FakeGameBuilder.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+function makeCharacter({ rendered = true } = {}) {
+	return { type: "character", sheet: { rendered, render: vi.fn() } };
+}
+
+function setup() {
+	const character = makeCharacter();
+	new FakeGameBuilder().withWorldActor(character).build();
+	return character;
+}
+
+describe("SteadingChanged.onUpdateActor", () => {
+	it("re-renders open character sheets when a steading's prosperity changes", () => {
+		const character = setup();
+		onUpdateActor({ type: "steading" }, { system: { attributes: { prosperity: { current: 2 } } } });
+		expect(character.sheet.render).toHaveBeenCalled();
+	});
+
+	it("re-renders when a steading debility changes", () => {
+		const character = setup();
+		onUpdateActor({ type: "steading" }, { system: { debilities: { lacking: true } } });
+		expect(character.sheet.render).toHaveBeenCalled();
+	});
+
+	it("re-renders when the steading is renamed (the display shows the name)", () => {
+		const character = setup();
+		onUpdateActor({ type: "steading" }, { name: "Stonetop" });
+		expect(character.sheet.render).toHaveBeenCalled();
+	});
+
+	it("ignores steading changes that the character sheet does not display", () => {
+		const character = setup();
+		onUpdateActor({ type: "steading" }, { system: { notes: "harvest festival soon" } });
+		expect(character.sheet.render).not.toHaveBeenCalled();
+	});
+
+	it("ignores updates to non-steading actors", () => {
+		const character = setup();
+		onUpdateActor({ type: "character" }, { system: { attributes: { prosperity: { current: 2 } } } });
+		expect(character.sheet.render).not.toHaveBeenCalled();
+	});
+
+	it("leaves closed character sheets alone", () => {
+		const character = makeCharacter({ rendered: false });
+		new FakeGameBuilder().withWorldActor(character).build();
+		onUpdateActor({ type: "steading" }, { system: { debilities: { lacking: true } } });
+		expect(character.sheet.render).not.toHaveBeenCalled();
+	});
+});
+
+describe("SteadingChanged.onSteadingCreatedOrDeleted", () => {
+	it("re-renders open character sheets when a steading appears or disappears", () => {
+		const character = setup();
+		onSteadingCreatedOrDeleted({ type: "steading" });
+		expect(character.sheet.render).toHaveBeenCalled();
+	});
+
+	it("ignores other actor types", () => {
+		const character = setup();
+		onSteadingCreatedOrDeleted({ type: "npc" });
+		expect(character.sheet.render).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Re-opens #37, auto-closed with the 0.13.0 branch deletion — rebased onto main (applies cleanly, all tests pass).

- `FoundrySteadingRepository` resolves the party's steading and exposes a `ProsperitySnapshot` on `OutfitSnapshot`; the outfit header shows it, with a "(lacking)" tooltip. Worlds without a steading actor are a clean no-op.
- With 0.13.0's multiple-steadings support in mind, the lookup prefers the steading named "Stonetop", then any renamed steading, so a stray default-named actor doesn't win. If you'd rather have an explicit "party steading" setting for this, happy to add one.
- `SteadingChanged` hooks re-render open character sheets when a steading's prosperity/debilities/name change (or one is created/deleted), so the display stays live.

Ticks off "Add prosperity to inventory tab" in TODO.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)