### PR TITLE
Docs: point art extraction at the "spreads" (2-up) PDF downloads

### DIFF
--- a/languages/en.json
+++ b/languages/en.json
@@ -285,7 +285,7 @@
 		},
 		"artInstaller": {
 			"title": "Install Book Artwork",
-			"intro": "The compendium can show the illustrations from the Stonetop books, but the illustrations are copyrighted and aren't shipped with the system. If you own the PDFs, select them below — Book II: The Wider World and Other Wonders and Book I: Stonetop.",
+			"intro": "The compendium can show the illustrations from the Stonetop books, but the illustrations are copyrighted and aren't shipped with the system. If you own the PDFs, select them below — Book II: The Wider World and Other Wonders and Book I: Stonetop. Use the \"spreads\" (two-page) editions of the PDFs: the single-page versions split the artwork that spans facing pages, so much of it can't be recognized.",
 			"chooseLabel": "Book PDF(s)",
 			"install": "Install Artwork",
 			"noFiles": "Select at least one Stonetop book PDF first.",

--- a/stonetop-art/README.md
+++ b/stonetop-art/README.md
@@ -5,12 +5,20 @@ can't be shipped with the system. This folder is where it goes. It starts empty 
 books, you can fill it from your own PDFs. If you don't, no problem: the game works normally, the
 pictures are just missing.
 
+## Which PDFs: use the "spreads" (2-up) downloads
+
+The vendor distributes each book in two layouts: **single pages** (1-up) and **two-page spreads**
+(2-up). **Use the spreads versions** — extraction matches images against a manifest of the books'
+illustrations, and the single-page builds re-encode many images and cut the paintings that span a
+two-page spread in half at the gutter, so only about half the art is recognized from them. From
+the spreads PDFs, everything is recovered.
+
 ## Installing from inside Foundry (recommended)
 
 You don't need this folder or any command line at all. In Foundry, go to
 **Settings → Configure Settings → Stonetop → Install Artwork**, select your book PDFs
-(Book II carries most of the art; Book I adds the steading illustration), and click
-**Install Artwork**. The illustrations are extracted right in your browser and uploaded to the
+(the spreads versions — Book II carries most of the art; Book I adds the steading
+illustration), and click **Install Artwork**. The illustrations are extracted right in your browser and uploaded to the
 server's `Data/stonetop-art/` folder — this works on hosted/remote servers too, since nothing
 touches your local filesystem.
 


### PR DESCRIPTION
Small docs-only follow-up to #43, from a field test of the art installer against the vendor's current downloads.

The vendor distributes each book in two layouts: single pages (1-up) and two-page spreads (2-up). Only the 2-up builds carry the illustrations as the whole images the art manifest was built from — the 1-up builds re-encode many images *and* cut every spread-spanning painting in half at the page gutter. Extraction from them (in-Foundry or CLI) recognizes only 117/206 manifest entries; the matching 2-up files recover 206/206 with clean exact-key integrity (the committed integration test passes against them).

This just says "use the spreads PDFs" in `stonetop-art/README.md` and in the Install Artwork dialog's intro text, so nobody else burns time on the wrong download.

(If 1-up support ever seems worth having, the fix would be placement-aware stitching of gutter-split images in `BookArtExtractor` plus perceptual signatures for all manifest entries — happy to share the diagnosis data, but the docs note seems like the right cost/benefit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)