### PR TITLE
Convert the NPC sheet to ApplicationV2

### DIFF
--- a/src/actors/npc/StonetopNpcSheet.js
+++ b/src/actors/npc/StonetopNpcSheet.js
@@ -16,8 +16,11 @@ export function createStonetopNpcSheetClass(Base) {
 
         static PARTS = {
             form: {
+                // No `scrollable`: the card's border frame is an inset:0 ::before, so the card
+                // itself must not scroll — .window-content is the scroll container instead, and
+                // it persists across V2 re-renders, so its scrollTop survives without part-level
+                // restore.
                 template: "systems/stonetop/templates/actor/npc.hbs",
-                scrollable: [""],
             },
         };
 

--- a/src/actors/npc/StonetopNpcSheet.js
+++ b/src/actors/npc/StonetopNpcSheet.js
@@ -1,4 +1,5 @@
 import { enrichRichTextTree } from "../../utils/enrichRichText.js";
+import { bindAll } from "../../utils/bindAll.js";
 
 export function createStonetopNpcSheetClass(Base) {
     return class StonetopNpcSheet extends Base {
@@ -8,80 +9,57 @@ export function createStonetopNpcSheetClass(Base) {
             this._stonetopNpc = this.actor.typedActor;
         }
 
-        static get defaultOptions() {
-            return foundry.utils.mergeObject(super.defaultOptions, {
-                classes: ["stonetop", "sheet", "actor", "npc"],
-                tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "description" }],
-                dragDrop: [{ dragSelector: ".items-list .item" }],
-				width: 315,
-				height: 425,
-            });
+        static DEFAULT_OPTIONS = {
+            classes: ["npc"],
+            position: { width: 315, height: 425 },
+        };
+
+        static PARTS = {
+            form: {
+                template: "systems/stonetop/templates/actor/npc.hbs",
+                scrollable: [""],
+            },
+        };
+
+        async _prepareContext(options) {
+            const context = await super._prepareContext(options);
+            context.actor = this.actor;
+            context.editable = this.isEditable;
+            context.stonetop = await this._stonetopNpc.buildSnapshot();
+            await enrichRichTextTree(context.stonetop, this.actor?.getRollData?.() ?? {});
+            return context;
         }
 
-        async getData() {
-			const ctx = await super.getData();
-			ctx.stonetop = await this._stonetopNpc.buildSnapshot();
-			await enrichRichTextTree(ctx.stonetop, this.actor?.getRollData?.() ?? {});
-			return ctx;
-		}
+        // Direct bindings to the card's controls — re-run per render (part content is replaced).
+        // Root-delegated behavior (edit toggles, steppers, comboboxes, rollables) lives in the base.
+        _onRender(context, options) {
+            super._onRender(context, options);
+            if (!this.isEditable) return;
+            const root = this.element;
+            const npc  = this._stonetopNpc;
 
-        activateListeners(html) {
-			super.activateListeners(html);
-			if (!this.isEditable) return;
+            // Creature core
+            bindAll(root, "#npc-hp", "change", ev => npc.setHp(ev.currentTarget.value));
+            bindAll(root, "#npc-max-hp", "change", ev => npc.setMaxHp(ev.currentTarget.value));
+            bindAll(root, "#npc-armor", "change", ev => npc.setArmor(ev.currentTarget.value));
+            bindAll(root, "#npc-damage", "change", ev => npc.setDamage(ev.currentTarget.value));
+            bindAll(root, "#npc-special-qualities", "change", ev => npc.setSpecialQuality(ev.currentTarget.value));
 
-			// HP
-			html.find("#npc-hp").on("change", async ev => {
-				await this._stonetopNpc.setHp(ev.currentTarget.value);
-			});
+            // Selection chips (tags) — toggle on click, add via free-text box.
+            bindAll(root, ".stonetop-tag-chip", "click", ev => {
+                const wrap = ev.currentTarget.closest(".stonetop-tags");
+                return npc.toggleSelection(wrap?.dataset.field, ev.currentTarget.dataset.tag);
+            });
+            bindAll(root, ".stonetop-tag-add", "change", ev => {
+                const value = ev.currentTarget.value.trim();
+                if (value) return npc.toggleSelection(ev.currentTarget.dataset.field, value);
+            });
+            // Instinct (single-select input + dropdown, not chips)
+            bindAll(root, ".stonetop-npc-instinct", "change", ev => npc.setInstinct(ev.currentTarget.value.trim()));
 
-			// HP
-			html.find("#npc-max-hp").on("change", async ev => {
-				await this._stonetopNpc.setMaxHp(ev.currentTarget.value);
-			});
-
-            // Armor
-			html.find("#npc-armor").on("change", async ev => {
-				await this._stonetopNpc.setArmor(ev.currentTarget.value);
-			});
-
-            // Damage
-			html.find("#npc-damage").on("change", async ev => {
-				await this._stonetopNpc.setDamage(ev.currentTarget.value);
-			});
-
-            // Special Quality
-			html.find("#npc-special-qualities").on("change", async ev => {
-				await this._stonetopNpc.setSpecialQuality(ev.currentTarget.value);
-			});
-
-			// Selection chips (tags, instinct) — toggle on click, add via free-text box.
-			html.find(".stonetop-tag-chip").on("click", async ev => {
-				const wrap = ev.currentTarget.closest(".stonetop-tags");
-				await this._stonetopNpc.toggleSelection(wrap?.dataset.field, ev.currentTarget.dataset.tag);
-			});
-			html.find(".stonetop-tag-add").on("change", async ev => {
-				const value = ev.currentTarget.value.trim();
-				if (value) await this._stonetopNpc.toggleSelection(ev.currentTarget.dataset.field, value);
-			});
-			// Instinct (single-select input + dropdown, not chips)
-			html.find(".stonetop-npc-instinct").on("change", async ev => {
-				await this._stonetopNpc.setInstinct(ev.currentTarget.value.trim());
-			});
-
-			// Moves
-			html.find("#npc-moves").on("change", async ev => {
-				await this._stonetopNpc.setMoves(ev.currentTarget.value);
-			});
-
-			 // Description
-			html.find(".stonetop-follower-description-textarea").on("change", async ev => {
-				await this._stonetopNpc.setDescription(ev.currentTarget.value);
-			});
-
-		}
-
-        get template() {
-            return "systems/stonetop/templates/actor/npc.hbs";
+            // Moves + description
+            bindAll(root, "#npc-moves", "change", ev => npc.setMoves(ev.currentTarget.value));
+            bindAll(root, ".stonetop-follower-description-textarea", "change", ev => npc.setDescription(ev.currentTarget.value));
         }
 
     };

--- a/stonetop.js
+++ b/stonetop.js
@@ -2,6 +2,7 @@ import { registerSettings } from "./src/settings.js";
 import { createStonetopActorClass } from "./src/actors/StonetopActor.js";
 import { createStonetopItemClass } from "./src/item/StonetopItem.js";
 import { StonetopActorSheet } from "./src/actors/StonetopActorSheet.js";
+import { createStonetopActorSheetV2Class } from "./src/actors/StonetopActorSheetV2.js";
 import { createStonetopCharacterSheetClass } from "./src/actors/character/StonetopCharacterSheet.js";
 import { createStonetopSteadingSheetClass } from "./src/actors/steading/StonetopSteadingSheet.js";
 import { createStonetopNpcSheetClass } from "./src/actors/npc/StonetopNpcSheet.js";
@@ -126,7 +127,11 @@ Hooks.once("init", () => {
 		label: "Stonetop Character Sheet",
 	});
 
-	const StonetopNpcSheet = createStonetopNpcSheetClass(StonetopActorSheet);
+	// The shared ApplicationV2 actor base: size memory + submitOnChange + root-delegated listeners
+	// (docs match the item base). NPC is on it; character + steading are still V1.
+	const ActorSheetV2Base = createStonetopActorSheetV2Class();
+
+	const StonetopNpcSheet = createStonetopNpcSheetClass(ActorSheetV2Base);
 	foundry.documents.collections.Actors.registerSheet("stonetop", StonetopNpcSheet, {
 		types: ["npc"],
 		makeDefault: true,

--- a/styles/stonetop.css
+++ b/styles/stonetop.css
@@ -4867,6 +4867,59 @@ form.stonetop.sheet.steading {
 	color: #1a1a1a;
 }
 
+/* ── NPC sheet (ApplicationV2) ──────────────────────────────────────────────
+   The V1 sheet leaned on core's legacy AppV1 sheet CSS — 100px .profile-img, .charname
+   sizing, window-content scrolling. V2 windows ship none of that, so the sheet owns it
+   here. Scroll lives on .window-content (NOT the card: the card's border frame is an
+   inset:0 ::before and would scroll away with the content); .window-content persists
+   across V2 re-renders, so its scroll position survives without part-level restore. */
+.stonetop.sheet.actor.npc .window-content {
+	overflow-y: auto;
+	padding: 8px;
+}
+.stonetop.sheet.actor.npc .stonetop-npc-card {
+	flex: 0 0 auto; /* natural height; overflow scrolls in the window-content */
+}
+
+/* Header row: the shared actor-header stretches, the framed HP box is pinned right. */
+.stonetop-npc-card .stonetop-npc-header-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.stonetop-npc-card .stonetop-npc-header-row > .sheet-header {
+	flex: 1 1 auto;
+	min-width: 0; /* lets the name column shrink instead of pushing the HP box out */
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+/* Core legacy CSS capped the portrait at 100px; without that it renders at natural size
+   and grows without bound as the window widens. */
+.stonetop-npc-card .profile-img {
+	flex: 0 0 100px;
+	width: 100px;
+	height: 100px;
+	object-fit: cover;
+}
+.stonetop-npc-card .header-fields {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+/* One rem step below the character sheet's --fs-name: the card is half as wide, and the
+   larger size clips descenders and truncates names next to the portrait. */
+.stonetop-npc-card .charname {
+	margin: 0;
+	border: none; /* no legacy h1 underline */
+}
+.stonetop-npc-card .charname input {
+	width: 100%;
+	height: auto;
+	font-size: var(--fs-display);
+	line-height: 1.3;
+}
+
 /* Moves block: a standard enriched <ul> (same rendering as move descriptions), with a
    pencil to edit the raw markdown. */
 .stonetop-creature-moves.stonetop-editable { display: block; }

--- a/templates/actor/npc.hbs
+++ b/templates/actor/npc.hbs
@@ -1,4 +1,5 @@
-<form class="{{cssClass}} stonetop-follower-card stonetop-npc-card" autocomplete="off">
+{{!-- V2 part: single root element; the sheet root form + classes come from DEFAULT_OPTIONS. --}}
+<div class="stonetop-follower-card stonetop-npc-card">
 
 	{{> "stonetop.actor-header"}}
 
@@ -43,4 +44,4 @@
 	{{> "stonetop.editable-rich-block" label=(localize "stonetop.followers.description")
 		field=stonetop.description textareaClass="stonetop-follower-description-textarea" slug=slug}}
 
-</form>
+</div>

--- a/templates/actor/npc.hbs
+++ b/templates/actor/npc.hbs
@@ -1,27 +1,9 @@
 {{!-- V2 part: single root element; the sheet root form + classes come from DEFAULT_OPTIONS. --}}
 <div class="stonetop-follower-card stonetop-npc-card">
 
-	{{> "stonetop.actor-header"}}
-
-	{{> "stonetop.selection-chips" sel=stonetop.tagSelection slug=slug field="tagList" placeholder=(localize "stonetop.followers.notePlaceholder")}}
-
-	<div class="stonetop-creature-statrow">
-		<div class="stonetop-creature-statrow__fields">
-			<div class="stonetop-creature-line">
-				<span class="stonetop-follower-label">{{localize "stonetop.followers.armor"}}</span>
-				{{> "stonetop.editable-field" field=stonetop.armor slug=slug
-					inputId="npc-armor" inputClass="stonetop-follower-armor"}}
-			</div>
-			<div class="stonetop-creature-line">
-				<span class="stonetop-follower-label">{{localize "stonetop.followers.damage"}}</span>
-				{{> "stonetop.editable-field" field=stonetop.damage slug=slug
-					inputId="npc-damage" inputClass="stonetop-follower-damage"}}
-			</div>
-			<div class="stonetop-creature-line">
-				<span class="stonetop-follower-label">{{localize "stonetop.followers.instinct"}}</span>
-				{{> "stonetop.selection-input" sel=stonetop.instinctSelection slug=slug field="instinct" inputClass="stonetop-npc-instinct" placeholder=(localize "stonetop.followers.instinct")}}
-			</div>
-		</div>
+	{{!-- Header row: portrait + name (shared partial) with the framed HP box pinned right. --}}
+	<div class="stonetop-npc-header-row">
+		{{> "stonetop.actor-header"}}
 		<div class="stonetop-creature-hp">
 			<span class="stonetop-follower-label">{{localize "stonetop.followers.hp"}}</span>
 			<div class="stonetop-creature-hp__row">
@@ -29,6 +11,25 @@
 				<span>/</span>
 				<input id="npc-max-hp" class="stonetop-creature-hp__input stonetop-step" type="number" min="0" value="{{stonetop.hpMax}}">
 			</div>
+		</div>
+	</div>
+
+	{{> "stonetop.selection-chips" sel=stonetop.tagSelection slug=slug field="tagList" placeholder=(localize "stonetop.followers.notePlaceholder")}}
+
+	<div class="stonetop-creature-statrow__fields">
+		<div class="stonetop-creature-line">
+			<span class="stonetop-follower-label">{{localize "stonetop.followers.armor"}}</span>
+			{{> "stonetop.editable-field" field=stonetop.armor slug=slug
+				inputId="npc-armor" inputClass="stonetop-follower-armor"}}
+		</div>
+		<div class="stonetop-creature-line">
+			<span class="stonetop-follower-label">{{localize "stonetop.followers.damage"}}</span>
+			{{> "stonetop.editable-field" field=stonetop.damage slug=slug
+				inputId="npc-damage" inputClass="stonetop-follower-damage"}}
+		</div>
+		<div class="stonetop-creature-line">
+			<span class="stonetop-follower-label">{{localize "stonetop.followers.instinct"}}</span>
+			{{> "stonetop.selection-input" sel=stonetop.instinctSelection slug=slug field="instinct" inputClass="stonetop-npc-instinct" placeholder=(localize "stonetop.followers.instinct")}}
 		</div>
 	</div>
 

--- a/templates/actor/partials/actor-header.hbs
+++ b/templates/actor/partials/actor-header.hbs
@@ -3,7 +3,9 @@
 	<img class="profile-img stonetop-header-playbook-icon" src="{{stonetop.playbook.img}}"
 	     alt="{{stonetop.playbook.name}}" title="{{stonetop.playbook.name}}">
 	{{else}}
-	<img class="profile-img" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" title="{{actor.name}}">
+	{{!-- data-edit: V1 core click binding; data-action: the V2 editImage action. Both present while
+	      the actor sheets straddle the migration. --}}
+	<img class="profile-img" src="{{actor.img}}" alt="{{actor.name}}" data-edit="img" data-action="editImage" title="{{actor.name}}">
 	{{/if}}
 	<div class="header-fields">
 		<h1 class="charname">

--- a/tests/actors/npc/npc-sheet-app.test.js
+++ b/tests/actors/npc/npc-sheet-app.test.js
@@ -1,23 +1,27 @@
+// @vitest-environment happy-dom
 import { describe, it, expect, vi } from "vitest";
 import { createStonetopNpcSheetClass } from "../../../src/actors/npc/StonetopNpcSheet.js";
 import { StonetopNpc } from "../../../src/actors/npc/StonetopNpc.js";
 import { FakeNpcActorBuilder } from "../../fakes/FakeNpcActorBuilder.js";
 
-// Drives the whole NPC sheet getData (real StonetopNpc + NpcSnapshot + RichText + the one
+// Drives the whole NPC sheet _prepareContext (real StonetopNpc + NpcSnapshot + RichText + the one
 // enrichRichTextTree pass) and proves a damage line's dice and a description's @UUID both come out
-// enriched. Only the Foundry enrichHTML boundary is mocked.
-function makeSheet(actor) {
+// enriched. Only the V2 actor-sheet base + the Foundry enrichHTML boundary are mocked.
+function makeSheet(actor, { editable = true } = {}) {
 	const Base = class {
 		get actor() { return actor; }
-		get isEditable() { return true; }
-		async getData() { return {}; }
-		activateListeners() {}
+		get isEditable() { return editable; }
+		async _prepareContext() { return {}; }
+		_onRender() {}
+		element = document.createElement("form");
 		render = vi.fn();
 	};
 	return new (createStonetopNpcSheetClass(Base))();
 }
 
-describe("StonetopNpcSheet.getData — rich-text enrichment (integration)", () => {
+const fire = (el, type) => el.dispatchEvent(new Event(type, { bubbles: true, cancelable: true }));
+
+describe("StonetopNpcSheet._prepareContext — rich-text enrichment (integration)", () => {
 	it("auto-rolls damage dice and links a description @UUID through the one pass", async () => {
 		const actor = new FakeNpcActorBuilder()
 			.withDamage("**maw** d10+2 (messy)")
@@ -32,7 +36,7 @@ describe("StonetopNpcSheet.getData — rich-text enrichment (integration)", () =
 			.replace(/@UUID\[[^\]]+\]\{([^}]+)\}/g, '<a class="content-link">$1</a>');
 		let ctx;
 		try {
-			ctx = await sheet.getData();
+			ctx = await sheet._prepareContext({});
 		} finally {
 			foundry.applications.ux.TextEditor.implementation.enrichHTML = orig;
 		}
@@ -42,5 +46,90 @@ describe("StonetopNpcSheet.getData — rich-text enrichment (integration)", () =
 		expect(ctx.stonetop.damage.render()).toContain("<strong>maw</strong>");
 		// description (roll:false) keeps prose but resolves the @UUID link.
 		expect(ctx.stonetop.description.render()).toContain('<a class="content-link">the Barrow</a>');
+		// the template reads these directly.
+		expect(ctx.actor).toBe(actor);
+		expect(ctx.editable).toBe(true);
+	});
+});
+
+describe("StonetopNpcSheet._onRender — direct bindings (V2 lifecycle)", () => {
+	// A spy typed actor: _onRender only routes DOM events to these setters, so the real
+	// StonetopNpc isn't needed here (it's exercised by the integration test above).
+	function makeSpyNpc() {
+		return {
+			setHp: vi.fn(), setMaxHp: vi.fn(), setArmor: vi.fn(), setDamage: vi.fn(),
+			setSpecialQuality: vi.fn(), toggleSelection: vi.fn(), setInstinct: vi.fn(),
+			setMoves: vi.fn(), setDescription: vi.fn(),
+		};
+	}
+
+	function renderSheet({ editable = true } = {}) {
+		const npc = makeSpyNpc();
+		const sheet = makeSheet({ typedActor: npc }, { editable });
+		sheet.element.innerHTML = `
+			<input id="npc-hp" type="number" value="3">
+			<input id="npc-max-hp" type="number" value="6">
+			<input id="npc-armor" value="1">
+			<input id="npc-damage" value="d8">
+			<input id="npc-special-qualities" value="flies">
+			<div class="stonetop-tags" data-field="tagList">
+				<span class="stonetop-tag-chip" data-tag="devious"></span>
+				<input class="stonetop-tag-add" data-field="tagList" value="  sneaky  ">
+			</div>
+			<input class="stonetop-npc-instinct" value=" To skulk ">
+			<textarea id="npc-moves">bite</textarea>
+			<textarea class="stonetop-follower-description-textarea">a rat</textarea>`;
+		sheet._onRender({}, {});
+		return { sheet, npc };
+	}
+
+	it("routes every field change to the matching typed-actor setter", () => {
+		const { sheet, npc } = renderSheet();
+		const el = sel => sheet.element.querySelector(sel);
+
+		fire(el("#npc-hp"), "change");
+		fire(el("#npc-max-hp"), "change");
+		fire(el("#npc-armor"), "change");
+		fire(el("#npc-damage"), "change");
+		fire(el("#npc-special-qualities"), "change");
+		fire(el("#npc-moves"), "change");
+		fire(el(".stonetop-follower-description-textarea"), "change");
+
+		expect(npc.setHp).toHaveBeenCalledWith("3");
+		expect(npc.setMaxHp).toHaveBeenCalledWith("6");
+		expect(npc.setArmor).toHaveBeenCalledWith("1");
+		expect(npc.setDamage).toHaveBeenCalledWith("d8");
+		expect(npc.setSpecialQuality).toHaveBeenCalledWith("flies");
+		expect(npc.setMoves).toHaveBeenCalledWith("bite");
+		expect(npc.setDescription).toHaveBeenCalledWith("a rat");
+	});
+
+	it("toggles a chip by its wrapper's field, adds trimmed free-text tags, trims the instinct", () => {
+		const { sheet, npc } = renderSheet();
+
+		fire(sheet.element.querySelector(".stonetop-tag-chip"), "click");
+		expect(npc.toggleSelection).toHaveBeenCalledWith("tagList", "devious");
+
+		fire(sheet.element.querySelector(".stonetop-tag-add"), "change");
+		expect(npc.toggleSelection).toHaveBeenCalledWith("tagList", "sneaky");
+
+		fire(sheet.element.querySelector(".stonetop-npc-instinct"), "change");
+		expect(npc.setInstinct).toHaveBeenCalledWith("To skulk");
+	});
+
+	it("ignores an empty free-text tag box", () => {
+		const { sheet, npc } = renderSheet();
+		const add = sheet.element.querySelector(".stonetop-tag-add");
+		add.value = "   ";
+		fire(add, "change");
+		expect(npc.toggleSelection).not.toHaveBeenCalled();
+	});
+
+	it("binds nothing when the sheet is not editable", () => {
+		const { sheet, npc } = renderSheet({ editable: false });
+		fire(sheet.element.querySelector("#npc-hp"), "change");
+		fire(sheet.element.querySelector(".stonetop-tag-chip"), "click");
+		expect(npc.setHp).not.toHaveBeenCalled();
+		expect(npc.toggleSelection).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## What

First **actor** sheet onto V2, following the pattern from the item-sheet conversions, and wiring up the shared `StonetopActorSheetV2` base (size memory, `submitOnChange`, root-delegated edit toggles / steppers / comboboxes / rollables) in `stonetop.js`. Character + steading stay on the V1 base.

- `defaultOptions` → `DEFAULT_OPTIONS` (the vestigial tabs/dragDrop config is dropped — the NPC card has neither), `get template()` → static `PARTS`
- `getData` → `_prepareContext` (`actor`/`editable` provided explicitly now that the V1 ActorSheet context is gone)
- `activateListeners` → `_onRender` + `bindAll`, handler bodies unchanged
- `npc.hbs` root `<form>` → `<div>` (the V2 sheet root IS the form; classes come from `DEFAULT_OPTIONS`)
- the shared `actor-header.hbs` profile img carries `data-action=editImage` alongside `data-edit=img` while the other actor sheets straddle the migration

## Field-tested regressions (second commit)

Deployed against a live world with real NPC actors; V2 windows do not ship the **legacy AppV1 sheet CSS** the V1 sheet silently relied on, which the second commit compensates for in `stonetop.css`:

- the portrait lost its legacy 100px cap → rendered at natural size and grew without bound when resizing the window; re-capped (with `object-fit: cover`)
- the name input clipped descenders and truncated early → fills the header column at one rem step below the character-sheet name size
- the sheet could not scroll at all → `.window-content` is the scroll container (the card's border frame is an `inset:0 ::before`, so the card itself must not scroll; since the V2 root persists across re-renders, scroll position survives with no part-level `scrollable`)
- the framed HP box moved up into the header row next to the name (its old spot right of the stat lines read oddly once everything else tightened up)

Heads-up for the character/steading conversions: they lean on the same legacy core CSS (`.profile-img` cap, `.charname` sizing, window scrolling), so they will hit the same three failure modes.

## Tests

`npc-sheet-app.test.js` reworked for the V2 lifecycle: the enrichment integration test drives `_prepareContext`, plus four new `_onRender` binding tests (field routing, chip toggle/free-text add/trim, empty-input guard, non-editable no-op). Full suite green: 178 files, 2302 passed / 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)