### PR TITLE
Fix NPC tag box losing an Enter-added tag to a double-toggle

### DIFF
--- a/src/actors/npc/StonetopNpcSheet.js
+++ b/src/actors/npc/StonetopNpcSheet.js
@@ -54,8 +54,16 @@ export function createStonetopNpcSheetClass(Base) {
                 return npc.toggleSelection(wrap?.dataset.field, ev.currentTarget.dataset.tag);
             });
             bindAll(root, ".stonetop-tag-add", "change", ev => {
-                const value = ev.currentTarget.value.trim();
-                if (value) return npc.toggleSelection(ev.currentTarget.dataset.field, value);
+                const input = ev.currentTarget;
+                const value = input.value.trim();
+                if (!value) return;
+                // Clear the box before toggling: pressing Enter fires TWO change events — the
+                // browser's native value-commit change AND comboBox's synthetic one — and a
+                // *toggle* handler that ran twice would add then immediately remove the tag
+                // (leaving the box blank, the tag uncommitted). Blanking the input makes the
+                // second change no-op via the guard above (matches the V1 character sheet).
+                input.value = "";
+                return npc.toggleSelection(input.dataset.field, value);
             });
             // Instinct (single-select input + dropdown, not chips)
             bindAll(root, ".stonetop-npc-instinct", "change", ev => npc.setInstinct(ev.currentTarget.value.trim()));

--- a/tests/actors/npc/npc-sheet-app.test.js
+++ b/tests/actors/npc/npc-sheet-app.test.js
@@ -125,6 +125,19 @@ describe("StonetopNpcSheet._onRender — direct bindings (V2 lifecycle)", () => 
 		expect(npc.toggleSelection).not.toHaveBeenCalled();
 	});
 
+	it("commits an Enter-added tag exactly once despite the paired change events", () => {
+		// Pressing Enter fires TWO change events (native value-commit + comboBox's synthetic one).
+		// Since toggleSelection *toggles*, firing it twice would add then remove the tag. The
+		// handler blanks the box on the first change so the second is guarded out — one net add.
+		const { sheet, npc } = renderSheet();
+		const add = sheet.element.querySelector(".stonetop-tag-add");
+		fire(add, "change");
+		fire(add, "change");
+		expect(npc.toggleSelection).toHaveBeenCalledTimes(1);
+		expect(npc.toggleSelection).toHaveBeenCalledWith("tagList", "sneaky");
+		expect(add.value).toBe("");
+	});
+
 	it("binds nothing when the sheet is not editable", () => {
 		const { sheet, npc } = renderSheet({ editable: false });
 		fire(sheet.element.querySelector("#npc-hp"), "change");


### PR DESCRIPTION
### Problem

On the NPC sheet, typing a tag in the free-text tag box and pressing **Enter** blanked the box without adding the tag. The only way to add one was the click-out (blur) workaround.

### Root cause

Pressing Enter fires **two** `change` events on the input — the browser's native value-commit change *plus* the synthetic one the shared combobox (`comboBox.js`) dispatches. The NPC tag handler calls `toggleSelection`, which **toggles**, so running it twice added the tag then immediately removed it → box blank, nothing committed.

The V1 character sheet's tag adder was immune only because it clears the input right after committing, so the second change hits its empty-value guard. The NPC V2 adder (from #45) never cleared, so it double-toggled.

### Fix

Blank the input before toggling in the NPC adder, matching the V1 character sheet. The second change then no-ops via the existing empty-value guard, so exactly one toggle lands.

### Tests

Added a regression test in `npc-sheet-app.test.js` that fires the paired change events and asserts a single toggle + a cleared box (red without the fix, green with it). Full suite green.

Field-verified in a live world on Foundry v13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)